### PR TITLE
Cleaned up themerandom.sh

### DIFF
--- a/themerandom.sh
+++ b/themerandom.sh
@@ -6,19 +6,10 @@
 ###################################
 
 # Get list of currently installed themes and count
-ls /etc/emulationstation/themes > /tmp/themes
-mkdir -p -- "/opt/retropie/configs/all/emulationstation/themes"
-ls /opt/retropie/configs/all/emulationstation/themes >> /tmp/themes
-themecount=`cat /tmp/themes |wc -l`
+rando_theme=$(ls -1 /etc/emulationstation/themes/|shuf|head -1)
 
 # Get the currently used theme name
-curtheme=`cat /opt/retropie/configs/all/emulationstation/es_settings.cfg |grep ThemeSet |cut -f4 -d '"'`
-
-# Generate a random number between 1 and theme count
-r=$(( $RANDOM % ${themecount} +1 ))
-
-# Read the random line in the tmp file to get a new theme name
-newtheme=`sed -n "${r}p" /tmp/themes`
+curtheme=$(grep ThemeSet /opt/retropie/configs/all/emulationstation/es_settings.cfg|cut -f4 -d '"')
 
 # Replace the current used theme with a new one
-perl -pi -w -e 's/<string name=\"ThemeSet\" value=\"'${curtheme}'\" \/>/<string name=\"ThemeSet\" value=\"'${newtheme}'\" \/>/g;' /opt/retropie/configs/all/emulationstation/es_settings.cfg
+perl -pi -w -e 's/<string name=\"ThemeSet\" value=\"'${curtheme}'\" \/>/<string name=\"ThemeSet\" value=\"'${rando_theme}'\" \/>/g;' /home/pi/.emulationstation/es_settings.cfg


### PR DESCRIPTION
Redid the logic to use less processes and not need to create a file to list out themes.  Also changed the location where the theme is set to `~/.emulationstation` directory rather than the system default under `/opt/retropie/configs/all/emulationstation/` (Easier to remove this version and still have a working system if there is an issue)